### PR TITLE
Give readonly access to .propertyName of KZPropertyDescriptor

### DIFF
--- a/KZPropertyMapper/KZPropertyDescriptor.h
+++ b/KZPropertyMapper/KZPropertyDescriptor.h
@@ -9,6 +9,7 @@
 
 @interface KZPropertyDescriptor : NSObject
 @property(nonatomic, copy, readonly) NSString *stringMapping;
+@property(nonatomic, copy, readonly) NSString *propertyName;
 
 + (instancetype)descriptorWithPropertyName:(NSString*)name andMapping:(NSString *)mapping;
 + (instancetype)descriptorWithPropertyName:(NSString*)name andMappings:(id)descriptors, ... NS_REQUIRES_NIL_TERMINATION;


### PR DESCRIPTION
Hey, I don't think there can be any harm if outside classes had access to propertyName.

I need to use it in the following situation: extract the external primary key from the mapping dictionary, given that we know internal primary key. That is:

```
		[mapping enumerateKeysAndObjectsUsingBlock:^(id key, KZPropertyDescriptor *description, BOOL *stop) {
			 if ([description isKindOfClass:[KZPropertyDescriptor class]] &&
				 [description.propertyName isEqualToString:modelPrimaryKey])
			 {
				 externalPrimaryKey = key;
				 *stop = YES;
			 }
		 }];
```

Do you mind merging it? 

Thanks fot great work!