### PR TITLE
Validates @encodes(id<SomeProtocol>) will pass

### DIFF
--- a/KZPropertyMapper/KZPropertyMapper.m
+++ b/KZPropertyMapper/KZPropertyMapper.m
@@ -225,6 +225,20 @@
   }
   
   NSString *propertyClassName = [typeEncoding substringWithRange:NSMakeRange(2, typeEncoding.length - 3)];
+
+  if ([propertyClassName hasPrefix:@"<"] && [propertyClassName hasSuffix:@">"]) {
+      NSScanner *protocolScanner = [NSScanner scannerWithString:propertyClassName];
+      protocolScanner.charactersToBeSkipped = [NSCharacterSet characterSetWithCharactersInString:@"<>"];
+      NSString *protocolString;
+      while ([protocolScanner scanCharactersFromSet:[NSCharacterSet alphanumericCharacterSet] intoString:&protocolString]) {
+          Protocol *protocol = NSProtocolFromString(protocolString);
+          if (![object conformsToProtocol:protocol]) {
+              return NO;
+          }
+      }
+      return YES; // Looks like it is "id<SomeProtocol>", and all protocols requirements are met
+  }
+
   Class propertyClass = NSClassFromString(propertyClassName);
   BOOL isSameTypeObject = ([object isKindOfClass:propertyClass]);
   


### PR DESCRIPTION
Mapping can fail for valid properties that include only protocol information. For instance, `id<MyProtocol>` will fail, despite the fact that `object` conforms to `SomeProtocol`. 

`@encode(id<SomeProtocol>)` has undocumented behavior which includes a property's `Protocol` information, as discussed in this [StackOverflow](http://stackoverflow.com/a/15693532) thread.

In the event of an `id<SomeProtocol>`, I've used an `NSScanner` to enumerate each `Protocol` and test for protocol conformance on `object`.