### PR TITLE
Fixed mapping to non-collection object when using KZProperty with NS_BLOCK_ASSERTIONS defined

### DIFF
--- a/Example/ExampleTests/KZPropertyMapperTests.m
+++ b/Example/ExampleTests/KZPropertyMapperTests.m
@@ -213,6 +213,19 @@ SPEC_BEGIN(KZPropertyMapperSpec)
           [[testObject.title should] beNil];
         });
         
+        it(@"should handle dictionary value when using KZProperty", ^{
+          sourceDictionary = @{@"testValue" : @{@"key" : @"value"}};
+          #ifndef NS_BLOCK_ASSERTIONS
+          [[theBlock(^{
+            testResult = [KZPropertyMapper mapValuesFrom:sourceDictionary toInstance:testObject usingMapping:@{@"testValue": KZPropertyT(testObject, title)}];
+          }) should] raise];
+          #else
+          testResult = [KZPropertyMapper mapValuesFrom:sourceDictionary toInstance:testObject usingMapping:@{@"testValue": KZPropertyT(testObject, title)}];
+          [[theValue(testResult) should] beFalse];
+          [[testObject.title should] beNil];
+          #endif
+        });
+        
         it(@"should handle array value", ^{
           sourceDictionary = @{@"testValue" : @[@"v1", @"v2"]};
           [[theBlock(^{

--- a/KZPropertyMapper/KZPropertyMapper.m
+++ b/KZPropertyMapper/KZPropertyMapper.m
@@ -174,8 +174,7 @@
     return NO;
   }
 
-  [self mapValue:value toInstance:instance usingStringMapping:descriptor.stringMapping sourceKey:sourceKey];
-  return YES;
+  return [self mapValue:value toInstance:instance usingStringMapping:descriptor.stringMapping sourceKey:sourceKey];
 }
 
 + (BOOL)setValue:(id)value onInstance:(id)instance usingKeyPath:(NSString *)targetKeyPath sourceKey:(NSString *)sourceKey


### PR DESCRIPTION
## Description

When mapping a collection into a non-collection type using KZProperty with NS_BLOCK_ASSERTIONS defined, BOOL result of the operation was returning YES when it should be returning NO.